### PR TITLE
Add allocation firehose

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ The Nomad cluster is specified via the `$NOMAD_ADDR` environment variable.
 
 The Nomad cluster is specified via the `$NOMAD_ADDR` environment variable.
 
+### `firehose`
+
+`nomad-helper firehose` will monitor all alocation changes in the Nomad cluster and emit each task state as a new event to either stdout, rabbitmq or kinesis.
+
+The script will use Consul to maintain leader and the last event time processed (saved on quit or every 10s).
+
+The Nomad cluster is specified via the `$NOMAD_ADDR` environment variable.
+
+The Consul cluster is specified via the `$CONSUL_HTTP_ADDR` environment variable.
+
+The sink type is specified via the `$SINK_TYPE` environment variable. Valid values are: stdout, kinesis and amqp.
+
+The `amqp` sink is configured using `$SINK_AMQP_CONNECTION`, `$SINK_AMQP_EXCHANGE` and `$SINK_AMQP_ROUTING_KEY` environment variables.
+
+The `kinesis` sink is configured using `$SINK_KINESIS_STREAM_NAME` and `$SINK_KINESIS_PARTITION_KEY` environment variables.
+
+The `stdout` sink do not have any configuration.
+
 ## Example Scale config
 
 ```

--- a/command/drain/app.go
+++ b/command/drain/app.go
@@ -1,4 +1,4 @@
-package main
+package drain
 
 import (
 	"fmt"
@@ -6,13 +6,14 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/nomad/api"
+	"github.com/seatgeek/nomad-helper/nomad"
 )
 
-func drainCommand() error {
+func App() error {
 	log.Info("Starting drain")
 
 	// Create Nomad API client
-	client, err := NewNomadClient()
+	client, err := nomad.NewNomadClient()
 	if err != nil {
 		return err
 	}

--- a/command/firehose/allocations.go
+++ b/command/firehose/allocations.go
@@ -34,6 +34,10 @@ type AllocationUpdate struct {
 	GroupName          string
 	TaskName           string
 	EvalID             string
+	TaskState          string
+	TaskFailed         bool
+	TaskStartedAt      time.Time
+	TaskFinishedAt     time.Time
 	TaskEvent          *nomad.TaskEvent
 }
 
@@ -207,6 +211,10 @@ func (f *AllocationFirehose) watch() {
 						GroupName:          allocation.TaskGroup,
 						TaskName:           taskName,
 						TaskEvent:          taskEvent,
+						TaskState:          taskInfo.State,
+						TaskFailed:         taskInfo.Failed,
+						TaskStartedAt:      taskInfo.StartedAt,
+						TaskFinishedAt:     taskInfo.FinishedAt,
 					}
 
 					f.Publish(payload)

--- a/command/firehose/allocations.go
+++ b/command/firehose/allocations.go
@@ -1,0 +1,29 @@
+package firehose
+
+// AllocationFirehose ...
+type AllocationFirehose struct {
+}
+
+// AllocationUpdate ...
+type AllocationUpdate struct {
+}
+
+// NewAllocationFirehose ...
+func NewAllocationFirehose() (*AllocationFirehose, error) {
+	return &AllocationFirehose{}, nil
+}
+
+// Start the firehose
+func (f *AllocationFirehose) Start() {
+
+}
+
+// Stop the firehose
+func (f *AllocationFirehose) Stop() {
+
+}
+
+// Publish an update from the firehose
+func (f *AllocationFirehose) Publish(update *AllocationUpdate) {
+
+}

--- a/command/firehose/allocations.go
+++ b/command/firehose/allocations.go
@@ -1,29 +1,235 @@
 package firehose
 
+import (
+	"encoding/json"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	consul "github.com/hashicorp/consul/api"
+	nomad "github.com/hashicorp/nomad/api"
+)
+
 // AllocationFirehose ...
 type AllocationFirehose struct {
+	nomadClient     *nomad.Client
+	consulClient    *consul.Client
+	consulSessionID string
+	consulLock      *consul.Lock
+	stopCh          chan struct{}
+	lastChangeTime  int64
 }
 
 // AllocationUpdate ...
 type AllocationUpdate struct {
+	Name               string
+	AllocationID       string
+	DesiredStatus      string
+	DesiredDescription string
+	ClientStatus       string
+	ClientDescription  string
+	JobID              string
+	GroupName          string
+	TaskName           string
+	EvalID             string
+	TaskEvent          *nomad.TaskEvent
 }
 
 // NewAllocationFirehose ...
-func NewAllocationFirehose() (*AllocationFirehose, error) {
-	return &AllocationFirehose{}, nil
+func NewAllocationFirehose(lock *consul.Lock, sessionID string) (*AllocationFirehose, error) {
+	nomadClient, err := nomad.NewClient(nomad.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	consulClient, err := consul.NewClient(consul.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &AllocationFirehose{
+		nomadClient:     nomadClient,
+		consulClient:    consulClient,
+		consulSessionID: sessionID,
+		consulLock:      lock,
+	}, nil
 }
 
 // Start the firehose
-func (f *AllocationFirehose) Start() {
+func (f *AllocationFirehose) Start() error {
+	// Restore the last change time from Consul
+	err := f.restoreLastChangeTime()
+	if err != nil {
+		return err
+	}
 
+	// Stop chan for all tasks to depend on
+	f.stopCh = make(chan struct{})
+
+	// setup signal handler for graceful shutdown
+	go f.signalHandler()
+
+	// watch for allocation changes
+	go f.watch()
+
+	//
+	go f.persistLastChangeTime()
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-f.stopCh:
+			return nil
+		}
+	}
 }
 
 // Stop the firehose
 func (f *AllocationFirehose) Stop() {
+	close(f.stopCh)
+	f.writeLastChangeTime()
+}
 
+// Read the Last Change Time from Consul KV, so we don't re-process tasks over and over on restart
+func (f *AllocationFirehose) restoreLastChangeTime() error {
+	kv, _, err := f.consulClient.KV().Get(consulLockValue, &consul.QueryOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Ensure we got
+	if kv != nil && kv.Value != nil {
+		sv := string(kv.Value)
+		v, err := strconv.ParseInt(sv, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		f.lastChangeTime = v
+		log.Infof("Restoring Last Change Time to %s", sv)
+	} else {
+		log.Info("No Last Change Time restore point, starting from scratch")
+	}
+
+	return nil
+}
+
+// Write the Last Change Time to Consul so if the process restarts,
+// it will try to resume from where it left off, not emitting tons of double events for
+// old events
+func (f *AllocationFirehose) persistLastChangeTime() {
+	ticker := time.NewTicker(10 * time.Second)
+
+	for {
+		select {
+		case <-f.stopCh:
+			break
+		case <-ticker.C:
+			f.writeLastChangeTime()
+		}
+	}
+}
+
+func (f *AllocationFirehose) writeLastChangeTime() {
+	v := strconv.FormatInt(f.lastChangeTime, 10)
+
+	log.Infof("Writing lastChangedTime to KV: %s", v)
+	kv := &consul.KVPair{
+		Key:     consulLockValue,
+		Value:   []byte(v),
+		Session: f.consulSessionID,
+	}
+	_, err := f.consulClient.KV().Put(kv, &consul.WriteOptions{})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 // Publish an update from the firehose
 func (f *AllocationFirehose) Publish(update *AllocationUpdate) {
+	log.Infof("%s -> %s -> %s: %s", update.JobID, update.GroupName, update.TaskName, update.TaskEvent.DriverMessage)
+	b, err := json.Marshal(update)
+	if err != nil {
+		log.Error(err)
+	}
 
+	log.Info(string(b))
+}
+
+// Continously watch for changes to the allocation list and publish it as updates
+func (f *AllocationFirehose) watch() {
+	q := &nomad.QueryOptions{WaitIndex: 1, AllowStale: true}
+
+	newMax := f.lastChangeTime
+
+	for {
+		allocations, meta, err := f.nomadClient.Allocations().List(q)
+		if err != nil {
+			log.Errorf("Unable to fetch allocations: %s", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		remoteWaitIndex := meta.LastIndex
+		localWaitIndex := q.WaitIndex
+
+		// Only work if the WaitIndex have changed
+		if remoteWaitIndex <= localWaitIndex {
+			log.Debugf("Allocations index is unchanged (%d <= %d)", remoteWaitIndex, localWaitIndex)
+			continue
+		}
+
+		log.Debugf("Allocations index is changed (%d <> %d)", remoteWaitIndex, localWaitIndex)
+
+		// Iterate allocations and find events that have changed since last run
+		for _, allocation := range allocations {
+			for taskName, taskInfo := range allocation.TaskStates {
+				for _, taskEvent := range taskInfo.Events {
+					if taskEvent.Time <= f.lastChangeTime {
+						continue
+					}
+
+					if taskEvent.Time > newMax {
+						newMax = taskEvent.Time
+					}
+
+					payload := &AllocationUpdate{
+						Name:               allocation.Name,
+						AllocationID:       allocation.ID,
+						EvalID:             allocation.EvalID,
+						DesiredStatus:      allocation.DesiredStatus,
+						DesiredDescription: allocation.DesiredDescription,
+						ClientStatus:       allocation.ClientStatus,
+						ClientDescription:  allocation.ClientDescription,
+						JobID:              allocation.JobID,
+						GroupName:          allocation.TaskGroup,
+						TaskName:           taskName,
+						TaskEvent:          taskEvent,
+					}
+
+					f.Publish(payload)
+				}
+			}
+		}
+
+		// Update WaitIndex and Last Change Time for next iteration
+		q.WaitIndex = meta.LastIndex
+		f.lastChangeTime = newMax
+	}
+}
+
+// Close the stopCh if we get a signal, so we can gracefully shut down
+func (f *AllocationFirehose) signalHandler() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	select {
+	case <-c:
+		log.Info("Caught signal, releasing lock and stopping...")
+		f.Stop()
+	case <-f.stopCh:
+		break
+	}
 }

--- a/command/firehose/app.go
+++ b/command/firehose/app.go
@@ -2,25 +2,79 @@ package firehose
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"github.com/hashicorp/nomad/api"
-	"github.com/seatgeek/nomad-helper/nomad"
+	consul "github.com/hashicorp/consul/api"
 )
 
+const (
+	consulLockKey   = "service/nomad-helper/firehose.lock"
+	consulLockValue = "service/nomad-helper/firehose.value"
+)
+
+// App ...
 func App() error {
-	client, err := nomad.NewNomadClient()
+	lock, sessionID, err := waitForLock()
+	if err != nil {
+		return err
+	}
+	defer lock.Unlock()
+
+	worker, err := NewAllocationFirehose(lock, sessionID)
 	if err != nil {
 		return err
 	}
 
-	jobStubs, _, err := client.Jobs().List(&api.QueryOptions{})
-
-	for _, jobStub := range jobStubs {
-		log.Infof("Evaluating %s", jobStub.Name)
-		_, _, err := client.Jobs().ForceEvaluate(jobStub.ID, &api.WriteOptions{})
-		if err != nil {
-			log.Errorf("  %s", err)
-		}
+	err = worker.Start()
+	if err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// Wait for exclusive lock to the Consul KV key.
+// This will ensure we are the only applicating running and processing
+// allocation events to the firehose
+func waitForLock() (*consul.Lock, string, error) {
+	client, err := consul.NewClient(consul.DefaultConfig())
+	if err != nil {
+		return nil, "", err
+	}
+
+	log.Info("Trying to acquire leader lock")
+	sessionID, err := session(client)
+	if err != nil {
+		return nil, "", err
+	}
+
+	lock, err := client.LockOpts(&consul.LockOptions{
+		Key:     consulLockKey,
+		Session: sessionID,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	_, err = lock.Lock(nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	log.Info("Lock acquired")
+	return lock, sessionID, nil
+}
+
+// Create a Consul session used for locks
+func session(c *consul.Client) (string, error) {
+	s := c.Session()
+	se := &consul.SessionEntry{
+		Name: "nomad-helper-firehose",
+		TTL:  "15s",
+	}
+
+	id, _, err := s.Create(se, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return id, nil
 }

--- a/command/firehose/app.go
+++ b/command/firehose/app.go
@@ -1,12 +1,13 @@
-package main
+package firehose
 
 import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/nomad/api"
+	"github.com/seatgeek/nomad-helper/nomad"
 )
 
-func reevaluateCommand() error {
-	client, err := NewNomadClient()
+func App() error {
+	client, err := nomad.NewNomadClient()
 	if err != nil {
 		return err
 	}

--- a/command/firehose/sink/kinesis.go
+++ b/command/firehose/sink/kinesis.go
@@ -1,0 +1,93 @@
+package sink
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+)
+
+// KinesisSink ...
+type KinesisSink struct {
+	session *session.Session
+	kinesis *kinesis.Kinesis
+	stopCh  chan interface{}
+	putCh   chan []byte
+}
+
+// NewKinesis ...
+func NewKinesis() *KinesisSink {
+	sess := session.Must(session.NewSession())
+	svc := kinesis.New(sess)
+
+	return &KinesisSink{
+		session: sess,
+		kinesis: svc,
+		stopCh:  make(chan interface{}),
+		putCh:   make(chan []byte, 1000),
+	}
+}
+
+// Start ...
+func (s *KinesisSink) Start() error {
+	// Stop chan for all tasks to depend on
+	s.stopCh = make(chan interface{})
+
+	// have 3 writers to kinesis
+	go s.write(1)
+	go s.write(2)
+	go s.write(3)
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-s.stopCh:
+			break
+		}
+		break
+	}
+
+	return nil
+}
+
+// Stop ...
+func (s *KinesisSink) Stop() {
+	log.Infof("[kinesis] ensure writer queue is empty (%d messages left)", len(s.putCh))
+
+	for len(s.putCh) > 0 {
+		log.Info("[kinesis] Waiting for queue to drain - (%d messages left)", len(s.putCh))
+		time.Sleep(1 * time.Second)
+	}
+
+	close(s.stopCh)
+}
+
+// Put ..
+func (s *KinesisSink) Put(data []byte) error {
+	s.putCh <- data
+
+	return nil
+}
+
+func (s *KinesisSink) write(id int) {
+	log.Infof("[kinesis/%d] Starting kinesis writer", id)
+
+	for {
+		select {
+		case data := <-s.putCh:
+			putOutput, err := s.kinesis.PutRecord(&kinesis.PutRecordInput{
+				Data:         data,
+				StreamName:   aws.String("nomad-allocation-stream"),
+				PartitionKey: aws.String("key1"),
+			})
+
+			if err != nil {
+				log.Errorf("[kinesis/%d] %s", id, err)
+			} else {
+				log.Infof("[kinesis/%d] %v", id, putOutput)
+			}
+		}
+	}
+}

--- a/command/firehose/sink/rabbitmq.go
+++ b/command/firehose/sink/rabbitmq.go
@@ -1,0 +1,127 @@
+package sink
+
+import (
+	"time"
+
+	"os"
+
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/streadway/amqp"
+)
+
+// RabbitmqSink ...
+type RabbitmqSink struct {
+	conn       *amqp.Connection
+	exchange   string
+	routingKey string
+	stopCh     chan interface{}
+	putCh      chan []byte
+}
+
+// NewRabbitmq ...
+func NewRabbitmq() (*RabbitmqSink, error) {
+	connStr := os.Getenv("SINK_AMQP_CONNECTION")
+	if connStr == "" {
+		return nil, fmt.Errorf("[sink/amqp] Missing SINK_AMQP_CONNECTION (example: amqp://guest:guest@127.0.0.1:5672/)")
+	}
+
+	exchange := os.Getenv("SINK_AMQP_EXCHANGE")
+	if exchange == "" {
+		return nil, fmt.Errorf("[sink/amqp] Missing SINK_AMQP_EXCHANGE")
+	}
+
+	routingKey := os.Getenv("SINK_AMQP_ROUTING_KEY")
+	if routingKey == "" {
+		return nil, fmt.Errorf("[sink/amqp] Mising SINK_AMQP_ROUTING_KEY")
+	}
+
+	conn, err := amqp.Dial(connStr)
+	if err != nil {
+		return nil, fmt.Errorf("[sink/amqp] Failed to connect to AMQP: %s", err)
+	}
+
+	return &RabbitmqSink{
+		conn:       conn,
+		exchange:   exchange,
+		routingKey: routingKey,
+		stopCh:     make(chan interface{}),
+		putCh:      make(chan []byte, 1000),
+	}, nil
+}
+
+// Start ...
+func (s *RabbitmqSink) Start() error {
+	// Stop chan for all tasks to depend on
+	s.stopCh = make(chan interface{})
+
+	// have 3 writers to rabbitmq
+	go s.write(1)
+	go s.write(2)
+	go s.write(3)
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-s.stopCh:
+			break
+		}
+		break
+	}
+
+	return nil
+}
+
+// Stop ...
+func (s *RabbitmqSink) Stop() {
+	log.Infof("[sink/amqp] ensure writer queue is empty (%d messages left)", len(s.putCh))
+
+	for len(s.putCh) > 0 {
+		log.Info("[sink/amqp] Waiting for queue to drain - (%d messages left)", len(s.putCh))
+		time.Sleep(1 * time.Second)
+	}
+
+	close(s.stopCh)
+	defer s.conn.Close()
+}
+
+// Put ..
+func (s *RabbitmqSink) Put(data []byte) error {
+	s.putCh <- data
+
+	return nil
+}
+
+func (s *RabbitmqSink) write(id int) {
+	log.Infof("[sink/amqp/%d] Starting writer", id)
+
+	ch, err := s.conn.Channel()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	defer ch.Close()
+
+	for {
+		select {
+		case data := <-s.putCh:
+			err = ch.Publish(
+				s.exchange,   // exchange
+				s.routingKey, // routing key
+				false,        // mandatory
+				false,        // immediate
+				amqp.Publishing{
+					ContentType: "application/json",
+					Body:        data,
+				})
+
+			if err != nil {
+				log.Errorf("[sink/amqp/%d] %s", id, err)
+			} else {
+				log.Debugf("[sink/amqp/%d] publish ok", id)
+			}
+		}
+	}
+}

--- a/command/firehose/sink/rabbitmq.go
+++ b/command/firehose/sink/rabbitmq.go
@@ -110,7 +110,7 @@ func (s *RabbitmqSink) write(id int) {
 			err = ch.Publish(
 				s.exchange,   // exchange
 				s.routingKey, // routing key
-				false,        // mandatory
+				true,         // mandatory
 				false,        // immediate
 				amqp.Publishing{
 					ContentType: "application/json",

--- a/command/firehose/sink/stdout.go
+++ b/command/firehose/sink/stdout.go
@@ -1,0 +1,56 @@
+package sink
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// StdoutSink ...
+type StdoutSink struct {
+	stopCh chan interface{}
+	putCh  chan []byte
+}
+
+// NewStdout ...
+func NewStdout() (*StdoutSink, error) {
+	return &StdoutSink{
+		stopCh: make(chan interface{}),
+		putCh:  make(chan []byte, 1000),
+	}, nil
+}
+
+// Start ...
+func (s *StdoutSink) Start() error {
+	// Stop chan for all tasks to depend on
+	s.stopCh = make(chan interface{})
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-s.stopCh:
+			break
+		}
+		break
+	}
+
+	return nil
+}
+
+// Stop ...
+func (s *StdoutSink) Stop() {
+	log.Infof("[sink/stdout] ensure writer queue is empty (%d messages left)", len(s.putCh))
+
+	for len(s.putCh) > 0 {
+		log.Info("[sink/stdout] Waiting for queue to drain - (%d messages left)", len(s.putCh))
+		time.Sleep(1 * time.Second)
+	}
+
+	close(s.stopCh)
+}
+
+// Put ..
+func (s *StdoutSink) Put(data []byte) error {
+	log.Infof("[sink/stdout] %s", string(data))
+	return nil
+}

--- a/command/gc/app.go
+++ b/command/gc/app.go
@@ -1,11 +1,12 @@
-package main
+package gc
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/seatgeek/nomad-helper/nomad"
 )
 
-func gcCommand() error {
-	client, err := NewNomadClient()
+func App() error {
+	client, err := nomad.NewNomadClient()
 	if err != nil {
 		return err
 	}

--- a/command/reevaluate/app.go
+++ b/command/reevaluate/app.go
@@ -1,0 +1,26 @@
+package reevaluate
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/nomad/api"
+	"github.com/seatgeek/nomad-helper/nomad"
+)
+
+func App() error {
+	client, err := nomad.NewNomadClient()
+	if err != nil {
+		return err
+	}
+
+	jobStubs, _, err := client.Jobs().List(&api.QueryOptions{})
+
+	for _, jobStub := range jobStubs {
+		log.Infof("Evaluating %s", jobStub.Name)
+		_, _, err := client.Jobs().ForceEvaluate(jobStub.ID, &api.WriteOptions{})
+		if err != nil {
+			log.Errorf("  %s", err)
+		}
+	}
+
+	return nil
+}

--- a/command/scale/export.go
+++ b/command/scale/export.go
@@ -1,9 +1,11 @@
-package main
+package scale
 
 import (
 	"io/ioutil"
 	"time"
 
+	"github.com/seatgeek/nomad-helper/nomad"
+	"github.com/seatgeek/nomad-helper/structs"
 	yaml "gopkg.in/yaml.v2"
 
 	"os"
@@ -12,10 +14,10 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
-func exportCommand(file string) error {
+func ExportCommand(file string) error {
 	log.Info("Reading jobs from Nomad")
 
-	client, err := NewNomadClient()
+	client, err := nomad.NewNomadClient()
 	if err != nil {
 		return err
 	}
@@ -31,9 +33,9 @@ func exportCommand(file string) error {
 	info["exported_at"] = time.Now().UTC().Format(time.RFC1123Z)
 	info["exported_by"] = os.Getenv("USER")
 
-	state := &NomadState{
+	state := &structs.NomadState{
 		Info: info,
-		Jobs: make(map[string]TaskGroupState),
+		Jobs: make(map[string]structs.TaskGroupState),
 	}
 
 	for _, jobStub := range jobStubs {
@@ -44,7 +46,7 @@ func exportCommand(file string) error {
 			log.Errorf("Could not fetch job %s", jobStub.Name)
 		}
 
-		jobState := TaskGroupState{}
+		jobState := structs.TaskGroupState{}
 
 		for _, group := range job.TaskGroups {
 			log.Infof("%s -> %s = %d", jobStub.Name, *group.Name, *group.Count)

--- a/command/scale/import.go
+++ b/command/scale/import.go
@@ -1,4 +1,4 @@
-package main
+package scale
 
 import (
 	"io/ioutil"
@@ -7,9 +7,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/nomad/api"
+	"github.com/seatgeek/nomad-helper/nomad"
+	"github.com/seatgeek/nomad-helper/structs"
 )
 
-func importCommand(file string) error {
+func ImportCommand(file string) error {
 	log.Info("Reading state file")
 
 	data, err := ioutil.ReadFile(file)
@@ -17,13 +19,13 @@ func importCommand(file string) error {
 		return err
 	}
 
-	localState := &NomadState{}
+	localState := &structs.NomadState{}
 	err = yaml.Unmarshal(data, &localState)
 	if err != nil {
 		return err
 	}
 
-	client, err := NewNomadClient()
+	client, err := nomad.NewNomadClient()
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/seatgeek/nomad-helper/command/drain"
+	"github.com/seatgeek/nomad-helper/command/firehose"
 	"github.com/seatgeek/nomad-helper/command/gc"
 	"github.com/seatgeek/nomad-helper/command/reevaluate"
 	"github.com/seatgeek/nomad-helper/command/scale"
@@ -72,6 +73,13 @@ func main() {
 			Usage: "Force a cluster GC",
 			Action: func(c *cli.Context) error {
 				return gc.App()
+			},
+		},
+		{
+			Name:  "firehose",
+			Usage: "Firehose emit cluster changes",
+			Action: func(c *cli.Context) error {
+				return firehose.App()
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -7,20 +7,12 @@ import (
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/seatgeek/nomad-helper/command/drain"
+	"github.com/seatgeek/nomad-helper/command/gc"
+	"github.com/seatgeek/nomad-helper/command/reevaluate"
+	"github.com/seatgeek/nomad-helper/command/scale"
 	cli "gopkg.in/urfave/cli.v1"
 )
-
-// JobState ...
-type JobState map[string]int
-
-// NomadState ...
-type NomadState struct {
-	Info map[string]string
-	Jobs map[string]TaskGroupState
-}
-
-// TaskGroupState ...
-type TaskGroupState map[string]int
 
 func main() {
 	app := cli.NewApp()
@@ -46,7 +38,7 @@ func main() {
 					return fmt.Errorf("Missing file name")
 				}
 
-				return exportCommand(configFile)
+				return scale.ExportCommand(configFile)
 			},
 		},
 		{
@@ -58,28 +50,28 @@ func main() {
 					return fmt.Errorf("Missing file name")
 				}
 
-				return importCommand(configFile)
+				return scale.ImportCommand(configFile)
 			},
 		},
 		{
 			Name:  "drain",
 			Usage: "Drain node and wait for all allocations to stop",
 			Action: func(c *cli.Context) error {
-				return drainCommand()
+				return drain.App()
 			},
 		},
 		{
 			Name:  "reevaluate-all",
 			Usage: "Force re-evaluate all jobs",
 			Action: func(c *cli.Context) error {
-				return reevaluateCommand()
+				return reevaluate.App()
 			},
 		},
 		{
 			Name:  "gc",
 			Usage: "Force a cluster GC",
 			Action: func(c *cli.Context) error {
-				return gcCommand()
+				return gc.App()
 			},
 		},
 	}

--- a/nomad/client.go
+++ b/nomad/client.go
@@ -1,4 +1,4 @@
-package main
+package nomad
 
 import "github.com/hashicorp/nomad/api"
 

--- a/structs/all.go
+++ b/structs/all.go
@@ -1,0 +1,13 @@
+package structs
+
+// JobState ...
+type JobState map[string]int
+
+// NomadState ...
+type NomadState struct {
+	Info map[string]string
+	Jobs map[string]TaskGroupState
+}
+
+// TaskGroupState ...
+type TaskGroupState map[string]int

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,178 @@
 			"revisionTime": "2017-06-01T21:44:32Z"
 		},
 		{
+			"checksumSHA1": "xBQ4KfJgkqMxnHVcOPHzwqTgRK8=",
+			"path": "github.com/aws/aws-sdk-go",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "nDW4/vdHc9LNbui2yq4TJpHJoc8=",
+			"path": "github.com/aws/aws-sdk-go/aws",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
+			"path": "github.com/aws/aws-sdk-go/aws/awserr",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
+			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
+			"path": "github.com/aws/aws-sdk-go/aws/client",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
+			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
+			"path": "github.com/aws/aws-sdk-go/aws/defaults",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
+			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "vUT1+nhQHFsMQ9AQtF+3jbEOmjM=",
+			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "NdSLt5tUXPmkmb9hWpIY/tqu10o=",
+			"path": "github.com/aws/aws-sdk-go/aws/request",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "Y20DEtMtbfE9qTtmoi2NYV1x7aA=",
+			"path": "github.com/aws/aws-sdk-go/aws/session",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "M11PbBLBimxBByeaakhFkhp7t7s=",
+			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
+			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "Yhbh4XxAWvT1et0e5Oa6J33BoNM=",
+			"path": "github.com/aws/aws-sdk-go/service/kinesis",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
+			"checksumSHA1": "VH5y62f+SDyEIqnTibiPtQ687i8=",
+			"path": "github.com/aws/aws-sdk-go/service/sts",
+			"revision": "68ee4df9ebc0459ab9b83e921037e621e70419db",
+			"revisionTime": "2017-07-06T22:56:49Z"
+		},
+		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
 			"revisionTime": "2016-10-29T20:57:26Z"
+		},
+		{
+			"checksumSHA1": "Ecn0UexWoWRG6Di0wdWvIfms/jc=",
+			"path": "github.com/go-ini/ini",
+			"revision": "3d73f4b845efdf9989fffd4b4e562727744a34ba",
+			"revisionTime": "2017-06-27T23:12:24Z"
 		},
 		{
 			"checksumSHA1": "5DBIm/bJOKLR3CbQH6wIELQDLlQ=",
@@ -109,6 +277,12 @@
 			"path": "github.com/hashicorp/serf/coordinate",
 			"revision": "91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc",
 			"revisionTime": "2017-06-14T22:59:51Z"
+		},
+		{
+			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",
+			"path": "github.com/jmespath/go-jmespath",
+			"revision": "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d",
+			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
 			"checksumSHA1": "+p4JY4wmFQAppCdlrJ8Kxybmht8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2016-12-05T14:13:22Z"
 		},
 		{
-			"checksumSHA1": "L4bajYItNZdsrcbvTza6vtLCDis=",
+			"checksumSHA1": "SodYLQcoCdaC65THb0YQJ7Qrkn4=",
 			"path": "github.com/hashicorp/consul/api",
-			"revision": "4b51d00458da8f6241498d7191b3daf1d1f81159",
-			"revisionTime": "2017-06-25T17:42:37Z"
+			"revision": "be782ae45ee346d0a7e83596dd97d19b310882a7",
+			"revisionTime": "2017-07-07T07:21:40Z"
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
@@ -159,5 +159,5 @@
 			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
-	"rootPath": "github.com/seatgeek/nomad-scale-helper"
+	"rootPath": "github.com/seatgeek/nomad-helper"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -309,6 +309,12 @@
 			"revisionTime": "2017-05-08T17:38:06Z"
 		},
 		{
+			"checksumSHA1": "3XsmaR3i5euGHpt150DerScyOco=",
+			"path": "github.com/streadway/amqp",
+			"revision": "2cbfe40c9341ad63ba23e53013b3ddc7989d801c",
+			"revisionTime": "2017-07-07T20:29:55Z"
+		},
+		{
 			"checksumSHA1": "9Zw986fuQM/hCoVd8vmHoSM+8sU=",
 			"path": "github.com/ugorji/go/codec",
 			"revision": "5efa3251c7f7d05e5d9704a69a984ec9f1386a40",


### PR DESCRIPTION
The idea is to monitor all cluster allocations, and on each allocation task state change, emit an event to a sink for other part of the your infrastructure to log, monitor and react to nomad changes

- [X] Ensure only one firehose can run at a time using Consul KV locks
- [X] Ensure the last event time is persistent to Consul every 10s and on shutdown. Preventing a process restart to fire of all the already seen events again.
- [X] Move existing code round to make it more maintainable
- [ ] Implement a sink for firehose updates (currently only to STDOUT)
  - [ ] RabbitMQ
  - [ ] SQS or SNS
  - [ ] DynamoDB
  - [ ] Kinesis
- [ ] Refactor, document and possible test the code
  - [ ] Make the consul lock/session handling more robust
  - [ ] Fix typo and missing doc blocks