### PR TITLE
Add json/json-pretty output option to "stats" command

### DIFF
--- a/helpers/client_list.go
+++ b/helpers/client_list.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -12,16 +13,25 @@ import (
 
 var (
 	nodeCache = make(map[string]*api.Node)
+	stderrLog *log.Logger
 )
 
+func init() {
+	// We make an logger that _always_ print to stderr to ensure CLI calls like
+	// "nomad-helper stats --output-format json | jq '.'" works. All progress and filtering
+	// output will go to stderr now instead of stdout for debug/info etc
+	stderrLog = log.New()
+	stderrLog.Out = os.Stderr
+}
+
 func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub, error) {
-	log.Info("Finding legible nodes")
+	stderrLog.Info("Finding legible nodes")
 	nodes, _, err := client.Nodes().List(&api.QueryOptions{Prefix: c.String("filter-prefix")})
 	if err != nil {
 		return nil, err
 	}
 
-	bar := progressbar.New(len(nodes))
+	bar := progressbar.NewOptions(len(nodes), progressbar.OptionSetWriter(os.Stderr))
 	if !c.Bool("no-progress") {
 		bar.RenderBlank()
 		defer func() {
@@ -33,25 +43,25 @@ func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub
 	for _, node := range nodes {
 		// only consider nodes that is ready
 		if node.Status != "ready" {
-			log.Debugf("Node %s is not in status=ready (%s)", node.Name, node.Status)
+			stderrLog.Debugf("Node %s is not in status=ready (%s)", node.Name, node.Status)
 			goto NEXT_NODE
 		}
 
 		// only consider nodes with the right node class
 		if class := c.String("filter-class"); class != "" && node.NodeClass != class {
-			log.Debugf("Node %s class '%s' do not match expected value '%s'", node.Name, node.NodeClass, class)
+			stderrLog.Debugf("Node %s class '%s' do not match expected value '%s'", node.Name, node.NodeClass, class)
 			goto NEXT_NODE
 		}
 
 		// only consider nodes with the right nomad version
 		if version := c.String("filter-version"); version != "" && node.Version != version {
-			log.Debugf("Node %s version '%s' do not match expected node version '%s'", node.Name, node.Version, version)
+			stderrLog.Debugf("Node %s version '%s' do not match expected node version '%s'", node.Name, node.Version, version)
 			goto NEXT_NODE
 		}
 
 		// only consider nodes with the right eligibility
 		if eligibility := c.String("filter-eligibility"); eligibility != "" && node.SchedulingEligibility != eligibility {
-			log.Debugf("Node %s eligibility '%s' do not match expected node eligibility '%s'", node.Name, node.SchedulingEligibility, eligibility)
+			stderrLog.Debugf("Node %s eligibility '%s' do not match expected node eligibility '%s'", node.Name, node.SchedulingEligibility, eligibility)
 			goto NEXT_NODE
 		}
 
@@ -66,7 +76,7 @@ func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub
 				value := split[1]
 
 				if nodeValue := getNodeMetaProperty(node.ID, key, client); nodeValue != value {
-					log.Debugf("Node %s Meta key '%s' value '%s' do not match expected '%s'", node.Name, key, nodeValue, value)
+					stderrLog.Debugf("Node %s Meta key '%s' value '%s' do not match expected '%s'", node.Name, key, nodeValue, value)
 					goto NEXT_NODE
 				}
 			}
@@ -83,14 +93,14 @@ func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub
 				value := split[1]
 
 				if nodeValue := getNodeAttributesProperty(node.ID, key, client); nodeValue != value {
-					log.Debugf("Node %s Attribute key '%s' value '%s' do not match expected '%s'", node.Name, key, nodeValue, value)
+					stderrLog.Debugf("Node %s Attribute key '%s' value '%s' do not match expected '%s'", node.Name, key, nodeValue, value)
 					goto NEXT_NODE
 				}
 			}
 		}
 
 		// continue to furhter processing
-		log.Debugf("Node %s passed all all filters", node.Name)
+		stderrLog.Debugf("Node %s passed all all filters", node.Name)
 		matches = append(matches, node)
 		goto NEXT_NODE
 
@@ -103,21 +113,21 @@ func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub
 
 	if !c.Bool("no-progress") {
 		bar.Finish()
-		fmt.Println()
+		fmt.Fprintln(os.Stderr, "")
 	}
 
-	log.Infof("Found %d matched nodes", len(matches))
+	stderrLog.Infof("Found %d matched nodes", len(matches))
 
 	// only work on specific percent of nodes
 	if percent := c.Int("percent"); percent < 100 {
-		log.Infof("Only %d percent of nodes should be used", percent)
-		matches = matches[0:len(matches) * percent / 100]
+		stderrLog.Infof("Only %d percent of nodes should be used", percent)
+		matches = matches[0 : len(matches)*percent/100]
 	}
 
 	// noop mode will fail the matching to prevent any further processing
 	if c.BoolT("noop") {
 		for _, node := range matches {
-			log.Infof("Node %s matched!", node.Name)
+			stderrLog.Infof("Node %s matched!", node.Name)
 		}
 		return nil, fmt.Errorf("noop mode, aborting")
 	}
@@ -132,7 +142,7 @@ func hasFilter(c *cli.Context, field string) bool {
 func getNodeMetaProperty(nodeID string, key string, client *api.Client) string {
 	node, err := lookupNode(nodeID, client)
 	if err != nil {
-		log.Errorf("Could not lookup the node in Nomad API: %s", err)
+		stderrLog.Errorf("Could not lookup the node in Nomad API: %s", err)
 		return ""
 	}
 
@@ -147,7 +157,7 @@ func getNodeMetaProperty(nodeID string, key string, client *api.Client) string {
 func getNodeAttributesProperty(nodeID string, key string, client *api.Client) string {
 	node, err := lookupNode(nodeID, client)
 	if err != nil {
-		log.Errorf("Could not lookup the node in Nomad API: %s", err)
+		stderrLog.Errorf("Could not lookup the node in Nomad API: %s", err)
 		return ""
 	}
 

--- a/helpers/client_list.go
+++ b/helpers/client_list.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func FilteredClientList(client *api.Client, c *cli.Context) ([]*api.NodeListStub, error) {
-	stderrLog.Info("Finding legible nodes")
+	stderrLog.Info("Finding eligible nodes")
 	nodes, _, err := client.Nodes().List(&api.QueryOptions{Prefix: c.String("filter-prefix")})
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -280,10 +280,16 @@ func main() {
 				cli.StringSliceFlag{
 					Name: "dimension",
 				},
+				cli.StringFlag{
+					Name:  "output-format",
+					Value: "table",
+					Usage: "Either `table, json or json-pretty`",
+				},
 			),
 			Action: func(c *cli.Context) error {
 				if err := stats.Run(c); err != nil {
-					panic(err)
+					log.Error(err)
+					return err
 				}
 				return nil
 			},

--- a/main.go
+++ b/main.go
@@ -288,8 +288,7 @@ func main() {
 			),
 			Action: func(c *cli.Context) error {
 				if err := stats.Run(c); err != nil {
-					log.Error(err)
-					return err
+					log.Fatal(err)
 				}
 				return nil
 			},


### PR DESCRIPTION
Added new CLI argument ` --output-format` to `stats` command.

```
$ nomad-helper stats -h
NAME:
   nomad-helper stats - Get cluster stats

USAGE:
   nomad-helper stats [command options] [arguments...]

OPTIONS:
   --filter-prefix ef30d57c                                   Filter nodes by their ID with prefix matching ef30d57c
   --filter-class batch-jobs                                  Filter nodes by their node class batch-jobs
   --filter-version 0.8.4                                     Filter nodes by their Nomad version 0.8.4
   --filter-eligibility eligible/ineligible                   Filter nodes by their eligibility status eligible/ineligible
   --percent value                                            Filter only specific percent of nodes percent of nodes (default: 100)
   --filter-meta 'aws.instance.availability-zone=us-east-1e'  Filter nodes by their meta key/value like 'aws.instance.availability-zone=us-east-1e'. Can be provided multiple times.
   --filter-attribute 'driver.docker.version=17.09.0-ce'      Filter nodes by their attribute key/value like 'driver.docker.version=17.09.0-ce'. Can be provided multiple times.
   --noop                                                     Only output nodes that would be drained, don't do any modifications
   --no-progress                                              Do not show progress bar
   --dimension value
   --output-format table, json or json-pretty                 Either table, json or json-pretty (default: "table")
```