### PR TITLE
feat: run system gc after removing jobs and before deleting a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ OPTIONS:
    --ignore-job value  Ignore a job ID when marking a namespace as empty. Can be provided multiple times.
 ```
 
+If jobs are ignored when removing a namespace, those jobs will be deleted _prior to_ the namespace being removed. A Nomad GC call will be run after any ignored jobs are removed to ensure that the removed state is synced to the cluster.
+
 ## node
 
 node specific commands that act on all Nomad clients that match the filters provided, rather than a single node

--- a/command/namespace/gc.go
+++ b/command/namespace/gc.go
@@ -75,6 +75,10 @@ func GC(c *cli.Context, logger *log.Logger) error {
 				}
 				logger.Infof("Job '%s' in region/namespace '%s/%s' successfully deleted", job.ID, region, namespace.Name)
 			}
+
+			if err := nomadClient.System().GarbageCollect(); err != nil {
+				return fmt.Errorf("error running garbage collection: %w", err)
+			}
 		}
 
 		if c.Bool("dry") {


### PR DESCRIPTION
Without this, sometimes a job will be marked as still existing after the namespace is deleted, causing a ton of log messages.